### PR TITLE
Server & module source map support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "test": "npm run lint"
   },
   "peerDependencies": {
-    "webpack": "*",
-    "source-map-support": "*"
+    "webpack": "*"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
@@ -26,6 +25,7 @@
     "webpack": "^1.12.12"
   },
   "dependencies": {
-    "webpack-partial": "^1.0.0"
+    "source-map-support": "^0.4.0",
+    "webpack-partial": "^1.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "webpack": "^1.12.12"
   },
   "dependencies": {
+    "source-map-loader": "^0.1.5",
     "source-map-support": "^0.4.0",
     "webpack-partial": "^1.1.2"
   }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,0 +1,2 @@
+import support from 'source-map-support';
+support.install();

--- a/src/source-maps.webpack.config.js
+++ b/src/source-maps.webpack.config.js
@@ -15,6 +15,15 @@ export default ({
     entry: enableRuntime && target === 'node' ?
       inject(entry, [runtime]) : entry,
 
+    // Include source-maps for libraries too!
+    module: {
+      loaders: [{
+        name: 'source-map',
+        test: /\.jsx?$/,
+        loader: require.resolve('source-map-loader'),
+      }],
+    },
+
     // Generate our own source-map files.
     plugins: [
       new SourceMapDevToolPlugin({

--- a/src/source-maps.webpack.config.js
+++ b/src/source-maps.webpack.config.js
@@ -3,7 +3,7 @@ import {SourceMapDevToolPlugin} from 'webpack';
 
 export default ({
   runtime: enableRuntime = process.env.NODE_ENV !== 'production',
-}) => (config) => {
+} = {}) => (config) => {
   const {entry, target} = config;
 
   // TODO: Generate real URLs using SOURCE_MAP_URL.

--- a/src/source-maps.webpack.config.js
+++ b/src/source-maps.webpack.config.js
@@ -1,28 +1,27 @@
-import partial from 'webpack-partial';
-import {BannerPlugin, SourceMapDevToolPlugin} from 'webpack';
+import {partial, inject} from 'webpack-partial';
+import {SourceMapDevToolPlugin} from 'webpack';
 
 export default ({
-  runtime = process.env.NODE_ENV !== 'production',
+  runtime: enableRuntime = process.env.NODE_ENV !== 'production',
 }) => (config) => {
-  const {target} = config;
+  const {entry, target} = config;
 
   // TODO: Generate real URLs using SOURCE_MAP_URL.
   const url = () => '[url]';
+  const runtime = require.resolve('./runtime.js');
 
   return partial(config, {
-    // Embed source map support for sane debugging. This kinda cheats by
-    // writing source map hooks at the top of every entrypoint.
+    // Embed source map support for sane debugging.
+    entry: enableRuntime && target === 'node' ?
+      inject(entry, [runtime]) : entry,
+
+    // Generate our own source-map files.
     plugins: [
-      ...target === 'node' && runtime ? [
-        new BannerPlugin('require("source-map-support").install();', {
-          raw: true,
-          entryOnly: false,
-        }),
-      ] : [],
       new SourceMapDevToolPlugin({
         test: /\.(css|js)($|\?)/,
         filename: 'map/[filebase].[hash].map',
         append: `\n//# sourceMappingURL=${url()}`,
+        moduleFilenameTemplate: '[resource-path]',
         module: true,
         columns: true,
       }),


### PR DESCRIPTION
This makes source maps work properly in `node` and for things in `node_modules`.

Having a peer seems to use some unreliable version that doesn't work. Injecting the code into the entrypoint with our version seems to be the recipe for success.

Use `source-map-loader` for source maps from other modules.
