### PR TITLE
Enable runtime by default.

### DIFF
--- a/src/source-maps.webpack.config.js
+++ b/src/source-maps.webpack.config.js
@@ -2,7 +2,7 @@ import {partial, inject} from 'webpack-partial';
 import {SourceMapDevToolPlugin} from 'webpack';
 
 export default ({
-  runtime: enableRuntime = process.env.NODE_ENV !== 'production',
+  runtime: enableRuntime = true,
 } = {}) => (config) => {
   const {entry, target} = config;
 


### PR DESCRIPTION
Be sensible. Make debugging suck less.
